### PR TITLE
Display or not Thumbnail lower bar new configuration

### DIFF
--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
@@ -328,12 +328,10 @@ class ImagePreview {
                 preview_fragment_main_add_btn.visibility = View.GONE
             }
 
-            if(mPreviewConfig.mUriList.size<2){
+            if(mPreviewConfig.mDisplayThumbnailLowerBar){
+                preview_fragment_bottom_ll.visibility = View.VISIBLE
+            }else{
                 preview_fragment_bottom_ll.visibility = View.GONE
-//                preview_fragment_main_add_btn.visibility = View.GONE
-//                preview_fragment_recyclerview_horizontal.visibility = View.GONE
-//                preview_fragment_right_shadow.visibility = View.GONE
-//                preview_fragment_left_shadow.visibility = View.GONE
             }
         }
 

--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/core/ImagePreviewConfig.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/core/ImagePreviewConfig.kt
@@ -8,6 +8,7 @@ import java.io.Serializable
  */
 class ImagePreviewConfig: Serializable {
     var mAllowAddButton: Boolean = false
+    var mDisplayThumbnailLowerBar: Boolean = true
     private set // the setter is private and has the default implementation
 
     companion object{
@@ -22,6 +23,14 @@ class ImagePreviewConfig: Serializable {
      */
     fun setAllowAddButton(value: Boolean): ImagePreviewConfig{
         mAllowAddButton = value
+        return this
+    }
+
+    /**
+     * @param value: false to hide add button, true to show add button
+     */
+    fun setDisplayThumbnailLowerBar(value: Boolean): ImagePreviewConfig{
+        mDisplayThumbnailLowerBar = value
         return this
     }
 


### PR DESCRIPTION
Implement possibility to display or not Thumbnail lower bar through configuration file.

Use the new feature like this.
```
ImagePreviewConfig config = new ImagePreviewConfig().setDisplayThumbnailLowerBar(true).setAllowAddButton(false).setUris(arrayList);
```
Before the bar automatically hided itself when uri list size was > 2 and displays otherwise. The problem is that it also hided the confirmation button. Now you can hide or display as you want passing one simple parameter.

Also removed dead code.

73k05