### PR TITLE
Config serializable

### DIFF
--- a/imagepreview/build.gradle
+++ b/imagepreview/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
 
     //image
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
 
     //image viewer
     implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.10.0'

--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
@@ -76,24 +76,6 @@ class ImagePreview {
             setOriginalState()
         }
 
-        private fun show() {
-            mActivity.get()?.window?.decorView?.systemUiVisibility = flag or
-                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-        }
-
-        private fun hide() {
-            mActivity.get()?.let {
-                flag = it.window.decorView.systemUiVisibility
-                it.window.decorView.systemUiVisibility =
-                    View.SYSTEM_UI_FLAG_FULLSCREEN or
-                            View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-                            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
-                            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
-                            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-            }
-
-        }
-
         fun dismissImagePreview(){
             if(mFragment!=null){
                 setOriginalState()
@@ -299,6 +281,7 @@ class ImagePreview {
             }
             preview_fragment_iv_done.setOnClickListener {
                 mOnPreviewFragmentListener?.onDone(mPreviewConfig.getUris())
+                onBackPressed()
             }
 
             preview_fragment_activity_toolbar.setNavigationOnClickListener {
@@ -314,9 +297,7 @@ class ImagePreview {
                 preview_fragment_main_add_btn.visibility = View.GONE
             }
 
-            if(mPreviewConfig.mDisplayThumbnailLowerBar){
-                preview_fragment_bottom_ll.visibility = View.VISIBLE
-            }else{
+            if(!mPreviewConfig.mDisplayThumbnailLowerBar || mPreviewConfig.mUriList.size<2){
                 preview_fragment_bottom_ll.visibility = View.GONE
             }
         }

--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
@@ -78,11 +78,6 @@ class ImagePreview {
             setOriginalState()
         }
 
-//        override fun onPagerClicked(isVisible: Boolean) {
-//            if (isVisible) { show() }
-//            else { hide() }
-//        }
-
         private fun show() {
             mActivity.get()?.window?.decorView?.systemUiVisibility = flag or
                     View.SYSTEM_UI_FLAG_LAYOUT_STABLE
@@ -119,7 +114,7 @@ class ImagePreview {
 
 
         private fun hideDefaultToolbar() {
-           // flag = mActivity.get()?.window?.decorView?.systemUiVisibility
+            // flag = mActivity.get()?.window?.decorView?.systemUiVisibility
             mActivity.get()?.let {
                 if (it is AppCompatActivity) {
                     if(it.supportActionBar == null){
@@ -177,11 +172,6 @@ class ImagePreview {
                     }
                 }
             }
-//            flag?.let {
-//                mActivity.get()?.window?.decorView?.systemUiVisibility = it or
-//                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
-//                        View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-//            }
         }
 
         private fun initStatusBar() {
@@ -243,7 +233,6 @@ class ImagePreview {
 
         private lateinit var mAdapterPager: ViewPagerAdapter
         private lateinit var mAdapterRecycler: ImageAdapter
-//        private var mList: ArrayList<Uri> = arrayListOf()
         private var mTopBottomBarIsVisible = true
         private var mPreviewConfig: ImagePreviewConfig = ImagePreviewConfig()
 
@@ -311,8 +300,7 @@ class ImagePreview {
                 mOnPreviewFragmentListener?.onAddBtnClicked()
             }
             preview_fragment_iv_done.setOnClickListener {
-                mOnPreviewFragmentListener?.onDone(mPreviewConfig.mUriList)
-                onBackPressed()
+                mOnPreviewFragmentListener?.onDone(mPreviewConfig.getUris())
             }
 
             preview_fragment_activity_toolbar.setNavigationOnClickListener {
@@ -342,7 +330,6 @@ class ImagePreview {
 
         private fun onBackPressed(){
             mOnPreviewFragmentListener?.onBackPressed()
-            //this.dismiss()
             fragmentManager?.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         }
 
@@ -368,7 +355,7 @@ class ImagePreview {
             mUiVisibilityFlag = preview_fragment_parent_fl.systemUiVisibility
             preview_fragment_parent_fl.systemUiVisibility =
                 View.SYSTEM_UI_FLAG_FULLSCREEN or
-                       //View.SYSTEM_UI_FLAG_LAYOUT_STABLE or //to get stable view this mUiVisibilityFlag sometime add views which disrupt our original views
+                        //View.SYSTEM_UI_FLAG_LAYOUT_STABLE or //to get stable view this mUiVisibilityFlag sometime add views which disrupt our original views
                         View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
                         View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
                         View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
@@ -386,7 +373,7 @@ class ImagePreview {
         private fun initAdapter() {
             /*recycler view*/
             mAdapterRecycler = ImageAdapter()
-            mAdapterRecycler.setData(mPreviewConfig.mUriList)
+            mAdapterRecycler.setData(mPreviewConfig.getUris())
             mAdapterRecycler.setListener(object : ImageAdapter.OnRecyclerImageClickListener {
                 override fun onRecyclerImageClick(index: Int) {
                     preview_fragment_viewpager.currentItem = index
@@ -398,7 +385,7 @@ class ImagePreview {
 
             /*view pager*/
             mAdapterPager = ViewPagerAdapter(childFragmentManager)
-            mAdapterPager.setData(mPreviewConfig.mUriList)
+            mAdapterPager.setData(mPreviewConfig.getUris())
             mAdapterPager.setListener(object : ViewPagerAdapter.OnViewPagerClickListener {
                 override fun onViewPagerClick() {
                     if (mTopBottomBarIsVisible) {

--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
@@ -297,7 +297,9 @@ class ImagePreview {
                 preview_fragment_main_add_btn.visibility = View.GONE
             }
 
-            if(!mPreviewConfig.mDisplayThumbnailLowerBar || mPreviewConfig.mUriList.size<2){
+            if(mPreviewConfig.mDisplayThumbnailLowerBar){
+                preview_fragment_bottom_ll.visibility = View.VISIBLE
+            }else{
                 preview_fragment_bottom_ll.visibility = View.GONE
             }
         }

--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
@@ -368,7 +368,10 @@ class ImagePreview {
             mAdapterPager.setListener(object : ViewPagerAdapter.OnViewPagerClickListener {
                 override fun onViewPagerClick() {
                     mTopBottomBarIsVisible = if (mTopBottomBarIsVisible) {
-                        hide()
+                        try {
+                            hide()
+                        }catch (e:IllegalStateException){
+                        }
                         false
                     } else {
                         show()

--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImagePreview.kt
@@ -328,12 +328,10 @@ class ImagePreview {
                 preview_fragment_main_add_btn.visibility = View.GONE
             }
 
-            if(mPreviewConfig.mUriList.size<2){
+            if(mPreviewConfig.mDisplayThumbnailLowerBar){
+                preview_fragment_bottom_ll.visibility = View.VISIBLE
+            }else{
                 preview_fragment_bottom_ll.visibility = View.GONE
-//                preview_fragment_main_add_btn.visibility = View.GONE
-//                preview_fragment_recyclerview_horizontal.visibility = View.GONE
-//                preview_fragment_right_shadow.visibility = View.GONE
-//                preview_fragment_left_shadow.visibility = View.GONE
             }
         }
 

--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/core/ImagePreviewConfig.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/core/ImagePreviewConfig.kt
@@ -9,14 +9,14 @@ import java.io.Serializable
 class ImagePreviewConfig: Serializable {
     var mAllowAddButton: Boolean = false
     var mDisplayThumbnailLowerBar: Boolean = true
-    private set // the setter is private and has the default implementation
+        private set // the setter is private and has the default implementation
 
     companion object{
         val ARG_BUNDLE = javaClass.canonicalName + ".bundle_arg"
     }
 
-    var mUriList: ArrayList<Uri> = arrayListOf()
-    private set
+    var mUriList: ArrayList<String> = arrayListOf()
+        private set
 
     /**
      * @param value: false to hide add button, true to show add button
@@ -38,7 +38,22 @@ class ImagePreviewConfig: Serializable {
      * @param value: array of uri to be sent for preview
      */
     fun setUris(value: ArrayList<Uri>): ImagePreviewConfig{
-        mUriList = value
+        var uris: ArrayList<String> = arrayListOf()
+        for(uri in value){
+            uris.add(uri.toString())
+        }
+        mUriList = uris
         return this
+    }
+
+    /**
+     * @param value: array of uri to be sent for preview
+     */
+    fun getUris(): ArrayList<Uri>{
+        var uris: ArrayList<Uri> = arrayListOf()
+        for(uri in mUriList){
+            uris.add(Uri.parse(uri))
+        }
+        return uris
     }
 }

--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/core/ImagePreviewConfig.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/core/ImagePreviewConfig.kt
@@ -8,6 +8,7 @@ import java.io.Serializable
  */
 class ImagePreviewConfig: Serializable {
     var mAllowAddButton: Boolean = false
+    var mDisplayThumbnailLowerBar: Boolean = true
     private set // the setter is private and has the default implementation
 
     companion object{
@@ -22,6 +23,14 @@ class ImagePreviewConfig: Serializable {
      */
     fun setAllowAddButton(value: Boolean): ImagePreviewConfig{
         mAllowAddButton = value
+        return this
+    }
+
+    /**
+     * @param value: false to hide add button, true to show add button
+     */
+    fun setDisplayThumbnailLowerBar(value: Boolean): ImagePreviewConfig{
+        mDisplayThumbnailLowerBar = value
         return this
     }
 


### PR DESCRIPTION
Make config class serializable in order **NOT** to close the fragment after pictures has been validated with the check/**done** button press.

Fragment is poped from stack very quickly, as a result, it's making the enclosing activity visible before the new intent has been properly opened. It is not user friendly because the views flickers.

Then we do not want to close the fragment too early but if we keep it open while a new intent is started, the config file tries to serialize itself. It is **not** possible and throws **NotSerializableException** because enclosing config Uri list is not serializable. 

So we convert Uris to serializable strings and later we get string back to Uris.

Then we can open the new intent without poping the fragment, after we have been used the activity, on return of it, we can finally close the fragment by calling dismissImagePreview(). I usually do that on the OnResume().

73k05