### PR TITLE
Fix IllegalArgumentException: pointerIndex out of range #8

### DIFF
--- a/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImageViewPager.kt
+++ b/imagepreview/src/main/java/com/greentoad/turtlebody/imagepreview/ImageViewPager.kt
@@ -1,0 +1,25 @@
+package com.greentoad.turtlebody.imagepreview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Log
+import android.view.MotionEvent
+import androidx.viewpager.widget.ViewPager
+
+
+/*********************
+ *    ViewPager
+ **********************/
+class ImageViewPager(context: Context, attrs: AttributeSet?) : ViewPager(context, attrs) {
+    private val TAG = "ImageViewPager"
+
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        try {
+            return super.onInterceptTouchEvent(ev)
+        } catch (ex: IllegalArgumentException) {
+            Log.e(TAG, "Error: " + ex.localizedMessage)
+        }
+        return false
+    }
+
+}

--- a/imagepreview/src/main/res/layout/tb_image_preview_fragment_preview.xml
+++ b/imagepreview/src/main/res/layout/tb_image_preview_fragment_preview.xml
@@ -10,7 +10,7 @@
     android:clickable="true"
     android:focusable="true">
 
-    <androidx.viewpager.widget.ViewPager
+    <com.greentoad.turtlebody.imagepreview.ImageViewPager
         android:id="@+id/preview_fragment_viewpager"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />


### PR DESCRIPTION
This fix permanently the Fatal Exception: java.lang.IllegalArgumentException
pointerIndex out of range in android.view.MotionEvent.nativeGetAxisValue from MotionEvent.java.